### PR TITLE
fix: bug that do not support languages

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -25,7 +25,7 @@ export class Chat {
 
     const res = await this.chatAPI.sendMessage(prompt, {
       promptPrefix: 'hi,',
-      promptSuffix: `\nlet's start` + (lang ? ', Answer me in ${lang}' : ''),
+      promptSuffix: `\nlet's start` + (lang ? `, Answer me in ${lang}` : ''),
     });
 
     console.timeEnd('code-review cost');


### PR DESCRIPTION
Language is not currently supported. Related Issues #39 
I think the problem is that it was using small quotes, not backticks.

