### PR TITLE
Use yarn instead of npm in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:18-slim
 WORKDIR /usr/src/app
-COPY package.json package-lock.json ./
-RUN npm ci --production
-RUN npm cache clean --force
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile
+RUN yarn cache clean
 ENV NODE_ENV="production"
 COPY . .
-CMD [ "npm", "start" ]
+CMD [ "yarn", "start" ]


### PR DESCRIPTION
There is yarn.lock in the repository, but there isn't package-lock.json in it. 

Switch to use yarn in Dockerfile will fix #80