### PR TITLE
Merge Dockerfile `yarn cache clean` and `yarn install` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:18-slim
 WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
-RUN yarn install --production --frozen-lockfile
-RUN yarn cache clean
+RUN yarn install --production --frozen-lockfile && yarn cache clean
 ENV NODE_ENV="production"
 COPY . .
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
They need to be in the same layer to make the cache clean meaningful.

Result:

```
REPOSITORY     TAG          IMAGE ID         CREATED        SIZE
after          latest       9daa14153ba8   2 hours ago     630MB
before         latest       b1fcdecb32f4   2 hours ago    2.82GB
```