### PR TITLE
Support custom OpenAI API endpoint

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -5,6 +5,7 @@ export class Chat {
   constructor(apikey: string) {
     this.chatAPI = new ChatGPTAPI({
       apiKey: apikey,
+      apiBaseUrl: process.env.OPENAI_API_ENDPOINT || 'https://api.openai.com/v1',
       completionParams: {
         model: process.env.MODEL || 'gpt-3.5-turbo',
         temperature: +(process.env.temperature || 0) || 1,


### PR DESCRIPTION
Setting custom endpoint can solve the problem of Chinese users not being able to directly access OpenAI's official API endpoint.