### PR TITLE
feat: support add ignore file

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -87,7 +87,7 @@ export const robot = (app: Probot) => {
           head: commits[commits.length - 1].sha,
         });
 
-        const ignoreList = JSON.parse(process.env.ignore || '[]');
+        const ignoreList = (process.env.IGNORE || process.env.ignore || '').split('\n').filter(v => v !== '');
 
         const filesNames = files?.map((file) => file.filename) || [];
         changedFiles = changedFiles?.filter((file) =>

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -87,9 +87,11 @@ export const robot = (app: Probot) => {
           head: commits[commits.length - 1].sha,
         });
 
+        const ignoreList = JSON.parse(process.env.ignore || '[]');
+
         const filesNames = files?.map((file) => file.filename) || [];
         changedFiles = changedFiles?.filter((file) =>
-          filesNames.includes(file.filename)
+          filesNames.includes(file.filename) && !ignoreList.includes(file.filename)
         );
       }
 


### PR DESCRIPTION
filter ignore file list, eg:

```
steps:
  - uses: anc95/ChatGPT-CodeReview@main
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
      # add ignore
      IGNORE/ignore: |
        yarn.lock
        README.md
```
filter some files, such as  README.md, yarn.lock/pnpm-lock.yaml,.gitignore, etc

for my resp: https://github.com/bingryan/WeChatAI/pull/52/files/64c88fa7c4c2b784ccfcb456c9f850649a3436d4
I hope the bot do not review .gitignore and pnpm-lock.yaml.

