### PR TITLE
fix: spelling and grammar errors in prompt

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -21,7 +21,7 @@ export class Chat {
 
     const prompt =
       process.env.PROMPT ||
-      'Bellow is the code patch, please help me do a brief code review, if any bug risk and improvement suggestion are welcome';
+        'Below is a code patch, please help me do a brief code review on it. Any bug risks and/or improvement suggestions are welcome:';
 
     return `${prompt}, ${answerLanguage}:
     ${patch}


### PR DESCRIPTION
I noticed the default prompt had a spelling error and some grammatical irregularities. Since the prompt is being used as an integral part of the process I thought I just thought I would clear them up for you real fast. 
 