### PR TITLE
fix: batch review comments to avoid secondary rate limit

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -8,6 +8,12 @@ const OPENAI_API_KEY = 'OPENAI_API_KEY';
 const MAX_PATCH_COUNT = process.env.MAX_PATCH_LENGTH
   ? +process.env.MAX_PATCH_LENGTH
   : Infinity;
+const REVIEW_BATCH_SIZE = process.env.REVIEW_BATCH_SIZE
+  ? +process.env.REVIEW_BATCH_SIZE
+  : 40;
+const REVIEW_BATCH_DELAY_MS = process.env.REVIEW_BATCH_DELAY_MS
+  ? +process.env.REVIEW_BATCH_DELAY_MS
+  : 5000;
 
 export const robot = (app: Probot) => {
   const loadChat = async (context: Context) => {
@@ -241,15 +247,39 @@ export const robot = (app: Probot) => {
         }
       }
       try {
-        await context.octokit.pulls.createReview({
-          repo: repo.repo,
-          owner: repo.owner,
-          pull_number: context.pullRequest().pull_number,
-          body: ress.length ? "Code review by ChatGPT" : "LGTM 👍",
-          event: 'COMMENT',
-          commit_id: context.payload.pull_request.head.sha,
-          comments: ress,
-        });
+        if (ress.length <= REVIEW_BATCH_SIZE) {
+          await context.octokit.pulls.createReview({
+            repo: repo.repo,
+            owner: repo.owner,
+            pull_number: context.pullRequest().pull_number,
+            body: ress.length ? "Code review by ChatGPT" : "LGTM 👍",
+            event: 'COMMENT',
+            commit_id: context.payload.pull_request.head.sha,
+            comments: ress,
+          });
+        } else {
+          // Submit comments in batches to avoid GitHub secondary rate limits
+          for (let i = 0; i < ress.length; i += REVIEW_BATCH_SIZE) {
+            const batch = ress.slice(i, i + REVIEW_BATCH_SIZE);
+            const isFirst = i === 0;
+            const isLast = i + REVIEW_BATCH_SIZE >= ress.length;
+
+            await context.octokit.pulls.createReview({
+              repo: repo.repo,
+              owner: repo.owner,
+              pull_number: context.pullRequest().pull_number,
+              body: isFirst ? "Code review by ChatGPT" : "",
+              event: 'COMMENT',
+              commit_id: context.payload.pull_request.head.sha,
+              comments: batch,
+            });
+
+            if (!isLast) {
+              log.info(`Submitted batch ${Math.floor(i / REVIEW_BATCH_SIZE) + 1}, waiting before next batch...`);
+              await new Promise((resolve) => setTimeout(resolve, REVIEW_BATCH_DELAY_MS));
+            }
+          }
+        }
       } catch (e) {
         log.info(`Failed to create review`, e);
         throw e;


### PR DESCRIPTION
## What

Split large review submissions into smaller batches to avoid GitHub's secondary rate limit.

Closes #201

## Why

When a PR has many changed files (100+), the review can contain hundreds of comments. Submitting all of them in a single `createReview` call triggers GitHub's [secondary rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits) which limits content-generating requests to 80 per minute. This causes an infinite retry loop as described in #201.

## How

- If comments count is within `REVIEW_BATCH_SIZE` (default: 40), behavior is unchanged — single API call
- If comments exceed the batch size, they are split into batches with a configurable delay between each batch (`REVIEW_BATCH_DELAY_MS`, default: 5000ms)
- The first batch carries the "Code review by ChatGPT" body (used for bot review detection in synchronize events)

## New environment variables (optional)

| Variable | Default | Description |
|----------|---------|-------------|
| `REVIEW_BATCH_SIZE` | 40 | Maximum comments per review API call |
| `REVIEW_BATCH_DELAY_MS` | 5000 | Delay in milliseconds between batch submissions |

## Testing

- TypeScript compilation passes (only pre-existing .cjs errors)
- Small PRs: no behavior change (single call path)
- Large PRs: comments split into batches with delay, avoiding secondary rate limit